### PR TITLE
import React so the TS-compiler doesn't insert a global scope

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import * as React from "react";
 
 export const LEFT = "Left";
 export const RIGHT = "Right";

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import * as React from 'react';
+
 export const LEFT = "Left";
 export const RIGHT = "Right";
 export const UP = "Up";


### PR DESCRIPTION
Because we were referencing React but not importing it the compiler saw it as a global which adds it as a reference.