### PR TITLE
only fire onTap once for touchend when tracking mouse and touch

### DIFF
--- a/__tests__/useSwipeable.spec.tsx
+++ b/__tests__/useSwipeable.spec.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { render, fireEvent, createEvent, act } from "@testing-library/react";
+import { render, fireEvent, act } from "@testing-library/react";
 import { useSwipeable } from "../src/index";
 import { LEFT, RIGHT, UP, DOWN, SwipeableProps } from "../src/types";
 import { expectSwipeFuncsDir } from "./helpers";
@@ -69,18 +69,25 @@ const cme = ({ x, y }: { x?: number; y?: number }) => ({
 
 describe("useSwipeable", () => {
   let defaultPreventedTouchMove = 0;
+  let defaultPreventedTouchEnd = 0;
 
   beforeAll(() => {
-    // listen on document for touchmove events, track if their default was prevented
+    // listen on document for touchmove & touchend events, track if their default was prevented
     document.addEventListener("touchmove", (e) => {
       if (e.defaultPrevented) {
         defaultPreventedTouchMove += 1;
+      }
+    });
+    document.addEventListener("touchend", (e) => {
+      if (e.defaultPrevented) {
+        defaultPreventedTouchEnd += 1;
       }
     });
   });
 
   beforeEach(() => {
     defaultPreventedTouchMove = 0;
+    defaultPreventedTouchEnd = 0;
   });
 
   it("handles onTap callbacks", () => {
@@ -110,19 +117,13 @@ describe("useSwipeable", () => {
     );
     const touchArea = getByText(TESTING_TEXT);
 
-    // Needed to create our own event and spy on preventDefault to verify
-    // "defaultPrevented" check is not working for some reason
-    // I dug into a lot of react-testing library code and the issue may actually be in jsdom /shrug
-    const touchEndEvent = createEvent.touchEnd(touchArea);
-    const pdSpy = jest.spyOn(touchEndEvent, "preventDefault");
-
     fireEvent[TS](touchArea, cte({ x: 100, y: 100 }));
     fireEvent[TM](touchArea, cte({ x: 101, y: 101 }));
-    fireEvent(touchArea, touchEndEvent);
+    fireEvent[TE](touchArea, cte({ x: 101, y: 101 }));
 
     // We are unable to test that onTap is only called once in this situation,
     // but we can verify that preventDefault was called correctly
-    expect(pdSpy).toHaveBeenCalled();
+    expect(defaultPreventedTouchEnd).toBe(1);
   });
 
   it("handles touch events that start at clientX or clientY 0", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -188,10 +188,17 @@ function getHandlers(
           ((props as any)[onSwipedDir] as SwipeCallback)(eventData);
         }
       } else if (props.onTap) {
-        // Only fire onTap once for touchEnd if tracking both mouse and touch events
-        props.trackMouse && props.trackTouch
-          ? event.type === touchEnd && props.onTap({ event })
-          : props.onTap({ event });
+        /**
+         * We want to only fire onTap once if tracking both mouse and touch events.
+         * By calling preventDefault on the touchend event this should stop the "mouseup" event from triggering
+         * when the event is a both a touch & "click". See issue/PR #231 & #234
+         * But still allow just a touch tap and just a mouse click/tap.
+         */
+        if (props.trackMouse && props.trackTouch && event.type === touchEnd) {
+          event.preventDefault();
+        }
+
+        props.onTap({ event });
       }
       return { ...state, ...initialState, eventData };
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -187,8 +187,11 @@ function getHandlers(
         if (onSwipedDir in props) {
           ((props as any)[onSwipedDir] as SwipeCallback)(eventData);
         }
-      } else {
-        props.onTap && props.onTap({ event });
+      } else if (props.onTap) {
+        // Only fire onTap once for touchEnd if tracking both mouse and touch events
+        props.trackMouse && props.trackTouch
+          ? event.type === touchEnd && props.onTap({ event })
+          : props.onTap({ event });
       }
       return { ...state, ...initialState, eventData };
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -229,13 +229,15 @@ function getHandlers(
       // attach touch event listeners and handlers
       const tls: [
         typeof touchStart | typeof touchMove | typeof touchEnd,
-        (e: HandledEvents) => void
+        (e: HandledEvents) => void,
+        AddEventListenerOptions
       ][] = [
-        [touchStart, onStart],
-        [touchMove, onMove],
-        [touchEnd, onEnd],
+        [touchStart, onStart, { passive }],
+        [touchMove, onMove, { passive }],
+        // we don't need passive option for touchend
+        [touchEnd, onEnd, {}],
       ];
-      tls.forEach(([e, h]) => el.addEventListener(e, h, { passive }));
+      tls.forEach(([e, h, options]) => el.addEventListener(e, h, options));
       // return properly scoped cleanup method for removing listeners, options not required
       cleanup = () => tls.forEach(([e, h]) => el.removeEventListener(e, h));
     }

--- a/tsconfig.all.json
+++ b/tsconfig.all.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.base.json",
-  "include": ["src/**/*", "examples/**/*", "__tests__"],
+  "include": ["src/**/*", "examples/**/*", "__tests__/**/*"],
  }


### PR DESCRIPTION
Fix for #231.

Only fire `onTap` once for `touchend` event when both `trackMouse` and `trackTouch` are `true`.