### PR TITLE
[WIP] - replace preventDefaultTouchmoveEvent with touchEventOptions

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -41,7 +41,7 @@ export type SwipeableCallbacks = {
 // Configuration Options
 export interface ConfigurationOptions {
   delta: number;
-  preventDefaultTouchmoveEvent: boolean;
+  touchEventOptions: AddEventListenerOptions;
   rotationAngle: number;
   trackMouse: boolean;
   trackTouch: boolean;
@@ -73,4 +73,7 @@ export type StateSetter = (
   props: SwipeablePropsWithDefaultOptions
 ) => SwipeableState;
 export type Setter = (stateSetter: StateSetter) => void;
-export type AttachTouch = (el: HTMLElement, passive: boolean) => () => void;
+export type AttachTouch = (
+  el: HTMLElement,
+  eventOptions: AddEventListenerOptions
+) => () => void;


### PR DESCRIPTION
Attempt to remove `preventDefaultTouchmoveEvent` which has always been a very complicated and hard to describe prop and replace it with `touchEventOptions`.

Mimicking our good friends over at https://use-gesture.netlify.app/docs/options/#eventoptions

#### `touchEventOptions: AddEventListenerOptions`
- defaults to `{ passive: true }`
- gives `react-swipeable` users more control over the events and when and if they want to call things like `event.preventDefault`

Possible solution for both #224 and #231.

TODOs:
- [ ] update/fix/add tests
- [ ] update documentation
- [ ] add migration from `preventDefaultTouchmoveEvent` and examples on how to prevent scrolling via calling `event.preventDefault` in user land manually
- [ ] add FAQ example for `onTap` solution when `trackTouch` and `trackMouse` are `true`