### PR TITLE
fix carousel ordering

### DIFF
--- a/examples/app/FeatureTestConsole/index.tsx
+++ b/examples/app/FeatureTestConsole/index.tsx
@@ -174,7 +174,7 @@ export default class Main extends Component<any, IState> {
             rotationAngle={rotationAngleNum}
             className="callout hookComponent"
             style={swipeableStyle}>
-              <div onTouchStart={()=>this.resetState()}>
+              <div onTouchStart={()=>this.resetState()} onMouseDown={()=>this.resetState()}>
                 <h5>Swipe inside here to test</h5>
                 <p>See output below and check the console for 'onSwiping' and 'onSwiped' callback output(open dev tools)</p>
                 <span>You can also 'toggle' the swiped props being applied to this container below.</span>

--- a/examples/app/SimpleCarousel/Carousel.tsx
+++ b/examples/app/SimpleCarousel/Carousel.tsx
@@ -20,17 +20,17 @@ interface CarouselState {
 
 type CarouselAction =
   | { type: Direction, numItems: number }
-  | { type: 'stopSliding' | 'reset' };
+  | { type: 'stopSliding' };
 
 const getOrder = (index: number, pos: number, numItems: number) => {
   return index - pos < 0 ? numItems - Math.abs(index - pos) : index - pos;
 };
 
-const initialState: CarouselState = { pos: 0, sliding: false, dir: NEXT };
+const getInitialState = (numItems: number): CarouselState => ({ pos: numItems - 1, sliding: false, dir: NEXT });
 
 const Carousel: FunctionComponent = (props) => {
-  const [state, dispatch] = React.useReducer(reducer, initialState);
   const numItems = React.Children.count(props.children);
+  const [state, dispatch] = React.useReducer(reducer, getInitialState(numItems));
 
   const slide = (dir: Direction) => {
     dispatch({ type: dir, numItems });
@@ -52,7 +52,6 @@ const Carousel: FunctionComponent = (props) => {
         <CarouselContainer dir={state.dir} sliding={state.sliding}>
           {React.Children.map(props.children, (child, index) => (
             <CarouselSlot
-              key={index}
               order={getOrder(index, state.pos, numItems)}
             >
               {child}
@@ -74,8 +73,6 @@ const Carousel: FunctionComponent = (props) => {
 
 function reducer(state: CarouselState, action: CarouselAction): CarouselState {
   switch (action.type) {
-    case 'reset':
-      return initialState;
     case PREV:
       return {
         ...state,

--- a/examples/app/SimplePattern/pattern.tsx
+++ b/examples/app/SimplePattern/pattern.tsx
@@ -37,7 +37,7 @@ interface CarouselState {
 
 type CarouselAction =
   | { type: Direction, numItems: number }
-  | { type: 'stopSliding' | 'reset' };
+  | { type: 'stopSliding' };
 
 const getOrder = (index: number, pos: number, numItems: number) => {
   return index - pos < 0 ? numItems - Math.abs(index - pos) : index - pos;
@@ -45,11 +45,11 @@ const getOrder = (index: number, pos: number, numItems: number) => {
 
 const pattern = [UP, DOWN, UP, DOWN];
 
-const initialState: CarouselState = { pos: 0, sliding: false, dir: NEXT };
+const getInitialState = (numItems: number): CarouselState => ({ pos: numItems - 1, sliding: false, dir: NEXT });
 
 const Carousel: FunctionComponent = (props) => {
-  const [state, dispatch] = React.useReducer(reducer, initialState);
   const numItems = React.Children.count(props.children);
+  const [state, dispatch] = React.useReducer(reducer, getInitialState(numItems));
 
   const slide = (dir: Direction) => {
     dispatch({ type: dir, numItems });
@@ -119,8 +119,6 @@ const Carousel: FunctionComponent = (props) => {
 
 function reducer(state: CarouselState, action: CarouselAction): CarouselState {
   switch (action.type) {
-    case 'reset':
-      return initialState;
     case PREV:
       return {
         ...state,


### PR DESCRIPTION
Fixes example carousels ordering issue. Now the first one is the actual first one displayed.

fixes #269 