### PR TITLE
setup touchEventOptions prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,17 @@
 # UNRELEASED
+
+**New Features:**
+- add new `touchEventOptions` prop that can set the options for the the touch event listeners
+  - this helps provides users full control of if/when they want to set [passive](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#options)
+
 **Breaking Changes:**
 * `preventScrollOnSwipe` - "new" prop. Replaces `preventDefaultTouchmoveEvent`
   * same functionality but renamed to be more explicit on its intended use
   * **fixed bug** - where toggling this prop did not re-attach event listeners
-  * **small update** - we now only change the `passive` event listener option for `touchmove` depending on this prop
+  * **update** - we now **only** change the `passive` event listener option for `touchmove` depending on this prop
     * see notes in README for more details [readme#passive-listener](https://github.com/FormidableLabs/react-swipeable#passive-listener)
   * Thank you [@stefvhuynh](https://github.com/stefvhuynh)
+
 **Bug fixes:**
 * fix bug where directional swiped check allowed `undefined`/falsy values to set `cancelablePageSwipe`
   * Thank you [@bhj](https://github.com/bhj) for the [comment](https://github.com/FormidableLabs/react-swipeable/pull/240#issuecomment-1014980025)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # UNRELEASED
 
 **New Features:**
-- add new `touchEventOptions` prop that can set the options for the the touch event listeners
-  - this helps provides users full control of if/when they want to set [passive](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#options)
+- add new `touchEventOptions` prop that can set the options for the touch event listeners
+  - this provides users full control of if/when they want to set [passive](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#options)
 - add new `onTouchStartOrOnMouseDown` prop that is called for `touchstart` and `mousedown`. Before a swipe even starts.
   - combined with `touchEventOptions` allows users the ability to now call `preventDefault` on `touchstart`
-- add new `onTouchEndOrOnMouseUp` prop that is always called for `touchend` and `mouseup`.
+- add new `onTouchEndOrOnMouseUp` prop that is called for `touchend` and `mouseup`.
 
 **Breaking Changes:**
 * we have dropped support for `es5` transpiled output

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 **New Features:**
 - add new `touchEventOptions` prop that can set the options for the the touch event listeners
   - this helps provides users full control of if/when they want to set [passive](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#options)
+- add new `onTouchStartOrOnMouseDown` prop that is called for `touchstart` and `mousedown`. Before a swipe even starts.
+  - combined with `touchEventOptions` allows users the ability to now call `preventDefault` on `touchstart`
 
 **Breaking Changes:**
 * `preventScrollOnSwipe` - "new" prop. Replaces `preventDefaultTouchmoveEvent`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   - this helps provides users full control of if/when they want to set [passive](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#options)
 - add new `onTouchStartOrOnMouseDown` prop that is called for `touchstart` and `mousedown`. Before a swipe even starts.
   - combined with `touchEventOptions` allows users the ability to now call `preventDefault` on `touchstart`
+- add new `onTouchEndOrOnMouseUp` prop that is always called for `touchend` and `mouseup`.
 
 **Breaking Changes:**
 * `preventScrollOnSwipe` - "new" prop. Replaces `preventDefaultTouchmoveEvent`

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Spread `handlers` onto the element you wish to track swipes on.
   onSwipeStart,   // Start of swipe    (SwipeEventData) => void *see details*
   onSwiping,      // During swiping    (SwipeEventData) => void
   onTap,          // After a tap       ({ event }) => void
+
+  // Pass through callbacks, event provided: ({ event }) => void
+  onTouchStartOrOnMouseDown, // Called for `touchstart` and `mousedown`
+  onTouchEndOrOnMouseUp,     // Called for `touchend` and `mouseup`
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -51,11 +51,13 @@ Spread `handlers` onto the element you wish to track swipes on.
 
 ```js
 {
-  delta: 10,                            // min distance(px) before a swipe starts. *See Notes*
-  preventScrollOnSwipe: false,          // prevents scroll during swipe in most cases (*See Details*)
-  trackTouch: true,                     // track touch input
-  trackMouse: false,                    // track mouse input
-  rotationAngle: 0,                     // set a rotation angle
+  delta: 10,                          // min distance(px) before a swipe starts. *See Notes*
+  preventScrollOnSwipe: false,        // prevents scroll during swipe (*See Details*)
+  trackTouch: true,                   // track touch input
+  trackMouse: false,                  // track mouse input
+  rotationAngle: 0,                   // set a rotation angle
+
+  touchEventOptions: { passive: true },  // options for touch listeners (*See Details*)
 }
 ```
 
@@ -68,6 +70,15 @@ Spread `handlers` onto the element you wish to track swipes on.
   delta: { top: 20, bottom: 20 } // top and bottom when ">= 20", left and right default to ">= 10"
 }
 ```
+
+#### touchEventOptions
+
+Allows the user to set the options for the touch event listeners.
+  - `touchstart`, `touchmove`, and `touchend` event listeners
+  - this provides users full control of if/when they want to set [passive](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#options)
+    - https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#options
+  - `preventScrollOnSwipe` option **supersedes** `touchEventOptions.passive` for `touchmove` event listener
+    - See `preventScrollOnSwipe` for [more details](#preventscrollonswipe-details)
 
 ## Swipe Event Data
 
@@ -98,22 +109,24 @@ All Event Handlers are called with the below event data, `SwipeEventData`.
 
 ### `preventScrollOnSwipe` details
 
-This prop prevents the browser's [touchmove](https://developer.mozilla.org/en-US/docs/Web/Events/touchmove) event default action (mostly scrolling) by calling `e.preventDefault()` internally.
+This prop prevents scroll during swipe in most cases. Use this to **stop scrolling** in the browser while a user swipes.
 
-Use this to **stop scrolling** in the browser while a user swipes.
+Swipeable will call `e.preventDefault()` internally in an attempt to stop the browser's [touchmove](https://developer.mozilla.org/en-US/docs/Web/Events/touchmove) event default action (mostly scrolling).
+
+**NOTE:** `preventScrollOnSwipe` option **supersedes** `touchEventOptions.passive` for `touchmove` event listener
+
+**Example scenario:**
+> If a user is swiping right with props `{ onSwipedRight: userSwipedRight, preventScrollOnSwipe: true }` then `e.preventDefault()` will be called, but if the user was swiping left then `e.preventDefault()` would **not** be called.
 
 `e.preventDefault()` is only called when:
   - `preventScrollOnSwipe: true`
   - `trackTouch: true`
   - the users current swipe has an associated `onSwiping` or `onSwiped` handler/prop
 
-Example scenario:
-> If a user is swiping right with props `{ onSwipedRight: userSwipedRight, preventScrollOnSwipe: true }` then `e.preventDefault()` will be called, but if the user was swiping left then `e.preventDefault()` would **not** be called.
-
 Please experiment with the [example app](http://formidablelabs.github.io/react-swipeable/) to test `preventScrollOnSwipe`.
 
-#### passive listener
-With v6 we've added the passive event listener option, by default, to **internal uses** of `addEventListener`. We set the `passive` option to `false` only when `preventScrollOnSwipe` is `true` and only `onTouchMove`. Other listeners will retain `passive: true`.
+#### passive listener details
+Swipeable adds the passive event listener option, by default, to **internal uses** of touch `addEventListener`'s. We set the `passive` option to `false` only when `preventScrollOnSwipe` is `true` and only to `touchmove`. Other listeners will retain `passive: true`.
 
 **When `preventScrollOnSwipe` is:**
   - `true`  => `el.addEventListener('touchmove', cb, { passive: false })`

--- a/__tests__/useSwipeable.spec.tsx
+++ b/__tests__/useSwipeable.spec.tsx
@@ -513,8 +513,7 @@ describe("useSwipeable", () => {
   it("defaults touchEventOptions passive", () => {
     const onSwiping = jest.fn();
 
-    // set to document to start to avoid TS issues
-    let addEventListenerSpy = jest.spyOn(document, "addEventListener");
+    let addEventListenerSpy: jest.SpyInstance | undefined;
     const onRefPassThrough = (el: HTMLElement) => {
       if (el === null) return;
       // re-assign to element and spy
@@ -534,8 +533,8 @@ describe("useSwipeable", () => {
     //   [ 'touchmove', [Function: onMove], { passive: true } ],
     //   [ 'touchend', [Function: onEnd], { passive: true } ]
     // ]
-    expect(addEventListenerSpy.mock.calls.length).toBe(3);
-    const calls = addEventListenerSpy.mock.calls;
+    expect(addEventListenerSpy?.mock.calls.length).toBe(3);
+    const calls = addEventListenerSpy?.mock.calls || [];
     touchListeners.forEach((l, idx) => {
       const [arg1, , arg3] = calls[idx] as any[];
       expect(arg1).toBe(l);
@@ -549,8 +548,7 @@ describe("useSwipeable", () => {
   it("preventScrollOnSwipe overwrites touchEventOptions passive", () => {
     const onSwiping = jest.fn();
 
-    // set to document to start to avoid TS issues
-    let addEventListenerSpy = jest.spyOn(document, "addEventListener");
+    let addEventListenerSpy: jest.SpyInstance | undefined;
     const onRefPassThrough = (el: HTMLElement) => {
       if (el === null) return;
       // re-assign to element and spy
@@ -565,8 +563,8 @@ describe("useSwipeable", () => {
       />
     );
 
-    expect(addEventListenerSpy.mock.calls.length).toBe(3);
-    const calls = addEventListenerSpy.mock.calls;
+    expect(addEventListenerSpy?.mock.calls.length).toBe(3);
+    const calls = addEventListenerSpy?.mock.calls || [];
     touchListeners.forEach((l, idx) => {
       const [arg1, , arg3] = calls[idx] as any[];
       expect(arg1).toBe(l);

--- a/__tests__/useSwipeable.spec.tsx
+++ b/__tests__/useSwipeable.spec.tsx
@@ -298,11 +298,13 @@ describe("useSwipeable", () => {
     );
   });
 
-  it("calls onTouchStartOrOnMouseDown for touch or mouse events", () => {
+  it("calls onTouchStartOrOnMouseDown and onTouchEndOrOnMouseUp for touch or mouse events", () => {
     const onTouchStartOrOnMouseDownMock = jest.fn();
+    const onTouchEndOrOnMouseUpMock = jest.fn();
     const { getByText, rerender } = render(
       <SwipeableUsingHook
         onTouchStartOrOnMouseDown={onTouchStartOrOnMouseDownMock}
+        onTouchEndOrOnMouseUp={onTouchEndOrOnMouseUpMock}
         trackMouse={true}
         trackTouch={false}
       />
@@ -318,10 +320,15 @@ describe("useSwipeable", () => {
     expect(onTouchStartOrOnMouseDownMock.mock.calls[0][0].event.type).toEqual(
       "mousedown"
     );
+    expect(onTouchEndOrOnMouseUpMock).toHaveBeenCalled();
+    expect(onTouchEndOrOnMouseUpMock.mock.calls[0][0].event.type).toEqual(
+      "mouseup"
+    );
 
     rerender(
       <SwipeableUsingHook
         onTouchStartOrOnMouseDown={onTouchStartOrOnMouseDownMock}
+        onTouchEndOrOnMouseUp={onTouchEndOrOnMouseUpMock}
       />
     );
 
@@ -332,6 +339,10 @@ describe("useSwipeable", () => {
     expect(onTouchStartOrOnMouseDownMock).toHaveBeenCalledTimes(2);
     expect(onTouchStartOrOnMouseDownMock.mock.calls[1][0].event.type).toEqual(
       "touchstart"
+    );
+    expect(onTouchEndOrOnMouseUpMock).toHaveBeenCalledTimes(2);
+    expect(onTouchEndOrOnMouseUpMock.mock.calls[1][0].event.type).toEqual(
+      "touchend"
     );
   });
 

--- a/__tests__/useSwipeable.spec.tsx
+++ b/__tests__/useSwipeable.spec.tsx
@@ -315,10 +315,14 @@ describe("useSwipeable", () => {
     fireEvent[MU](document, cme({}));
 
     expect(onTouchStartOrOnMouseDownMock).toHaveBeenCalled();
-    expect(onTouchStartOrOnMouseDownMock.mock.calls[0][0].event.type).toEqual('mousedown');
+    expect(onTouchStartOrOnMouseDownMock.mock.calls[0][0].event.type).toEqual(
+      "mousedown"
+    );
 
     rerender(
-      <SwipeableUsingHook onTouchStartOrOnMouseDown={onTouchStartOrOnMouseDownMock} />
+      <SwipeableUsingHook
+        onTouchStartOrOnMouseDown={onTouchStartOrOnMouseDownMock}
+      />
     );
 
     fireEvent[TS](touchArea, cte({ x: 100, y: 100 }));
@@ -326,7 +330,9 @@ describe("useSwipeable", () => {
     fireEvent[TE](touchArea, cte({}));
 
     expect(onTouchStartOrOnMouseDownMock).toHaveBeenCalledTimes(2);
-    expect(onTouchStartOrOnMouseDownMock.mock.calls[1][0].event.type).toEqual('touchstart');
+    expect(onTouchStartOrOnMouseDownMock.mock.calls[1][0].event.type).toEqual(
+      "touchstart"
+    );
   });
 
   it("correctly calls onSwipeStart for first swipe event", () => {

--- a/__tests__/useSwipeable.spec.tsx
+++ b/__tests__/useSwipeable.spec.tsx
@@ -498,9 +498,9 @@ describe("useSwipeable", () => {
     expect(addEventListenerSpy.mock.calls.length).toBe(3);
     const calls = addEventListenerSpy.mock.calls;
     touchListeners.forEach((l, idx) => {
-      const call: any = calls[idx];
-      expect(call[0]).toBe(l);
-      expect(call[2]).toEqual({ passive: true });
+      const [arg1, , arg3] = calls[idx] as any[];
+      expect(arg1).toBe(l);
+      expect(arg3).toEqual({ passive: true });
     });
 
     expect(onSwiping).not.toHaveBeenCalled();
@@ -529,13 +529,13 @@ describe("useSwipeable", () => {
     expect(addEventListenerSpy.mock.calls.length).toBe(3);
     const calls = addEventListenerSpy.mock.calls;
     touchListeners.forEach((l, idx) => {
-      const call: any = calls[idx];
-      expect(call[0]).toBe(l);
+      const [arg1, , arg3] = calls[idx] as any[];
+      expect(arg1).toBe(l);
       if (l === touchMove) {
         // preventScrollOnSwipe overrides passive for touchmove
-        expect(call[2]).toEqual({ passive: false });
+        expect(arg3).toEqual({ passive: false });
       } else {
-        expect(call[2]).toEqual({ passive: true });
+        expect(arg3).toEqual({ passive: true });
       }
     });
 

--- a/__tests__/useSwipeable.spec.tsx
+++ b/__tests__/useSwipeable.spec.tsx
@@ -298,6 +298,37 @@ describe("useSwipeable", () => {
     );
   });
 
+  it("calls onTouchStartOrOnMouseDown for touch or mouse events", () => {
+    const onTouchStartOrOnMouseDownMock = jest.fn();
+    const { getByText, rerender } = render(
+      <SwipeableUsingHook
+        onTouchStartOrOnMouseDown={onTouchStartOrOnMouseDownMock}
+        trackMouse={true}
+        trackTouch={false}
+      />
+    );
+
+    const touchArea = getByText(TESTING_TEXT);
+
+    fireEvent[MD](touchArea, cme({ x: 100, y: 100 }));
+    fireEvent[MM](touchArea, cme({ x: 125, y: 100 }));
+    fireEvent[MU](document, cme({}));
+
+    expect(onTouchStartOrOnMouseDownMock).toHaveBeenCalled();
+    expect(onTouchStartOrOnMouseDownMock.mock.calls[0][0].event.type).toEqual('mousedown');
+
+    rerender(
+      <SwipeableUsingHook onTouchStartOrOnMouseDown={onTouchStartOrOnMouseDownMock} />
+    );
+
+    fireEvent[TS](touchArea, cte({ x: 100, y: 100 }));
+    fireEvent[TM](touchArea, cte({ x: 100, y: 125 }));
+    fireEvent[TE](touchArea, cte({}));
+
+    expect(onTouchStartOrOnMouseDownMock).toHaveBeenCalledTimes(2);
+    expect(onTouchStartOrOnMouseDownMock.mock.calls[1][0].event.type).toEqual('touchstart');
+  });
+
   it("correctly calls onSwipeStart for first swipe event", () => {
     const onSwipeStart = jest.fn();
     const { getByText } = render(

--- a/__tests__/useSwipeable.spec.tsx
+++ b/__tests__/useSwipeable.spec.tsx
@@ -11,6 +11,11 @@ const DIRECTIONS: [typeof LEFT, typeof RIGHT, typeof UP, typeof DOWN] = [
   DOWN,
 ];
 
+const touchStart = "touchstart";
+const touchMove = "touchmove";
+const touchEnd = "touchend";
+const touchListeners = [touchStart, touchMove, touchEnd];
+
 export type MockedSwipeFunctions = {
   onSwiping: jest.Mock;
   onSwiped: jest.Mock;
@@ -36,12 +41,24 @@ const TESTING_TEXT = "touch here";
  */
 function SwipeableUsingHook({
   nodeName = "div",
+  onRefPassThrough,
   ...rest
-}: SwipeableProps & { nodeName?: string }) {
+}: SwipeableProps & {
+  nodeName?: string;
+  onRefPassThrough?(el: HTMLElement): void;
+}) {
   const eventHandlers = useSwipeable(rest);
   const Elem = nodeName as React.ElementType;
+
+  const refPassthrough = (el: HTMLElement) => {
+    onRefPassThrough?.(el);
+
+    // call useSwipeable ref prop with el
+    eventHandlers.ref(el);
+  };
+
   return (
-    <Elem {...eventHandlers}>
+    <Elem {...eventHandlers} ref={refPassthrough}>
       <span>{TESTING_TEXT}</span>
     </Elem>
   );
@@ -415,6 +432,131 @@ describe("useSwipeable", () => {
 
     expect(onSwipedDown).toHaveBeenCalled();
     expect(defaultPrevented).toBe(2);
+  });
+
+  it("defaults touchEventOptions passive", () => {
+    const onSwiping = jest.fn();
+
+    // set to document to start to avoid TS issues
+    let addEventListenerSpy = jest.spyOn(document, "addEventListener");
+    const onRefPassThrough = (el: HTMLElement) => {
+      if (el === null) return;
+      // re-assign to element and spy
+      addEventListenerSpy = jest.spyOn(el, "addEventListener");
+    };
+
+    render(
+      <SwipeableUsingHook
+        onSwiping={onSwiping}
+        onRefPassThrough={onRefPassThrough}
+      />
+    );
+
+    // NOTE: this is what addEventListenerSpy.mock.calls looks like:
+    // [
+    //   [ 'touchstart', [Function: onStart], { passive: true } ],
+    //   [ 'touchmove', [Function: onMove], { passive: true } ],
+    //   [ 'touchend', [Function: onEnd], { passive: true } ]
+    // ]
+    expect(addEventListenerSpy.mock.calls.length).toBe(3);
+    const calls = addEventListenerSpy.mock.calls;
+    touchListeners.forEach((l, idx) => {
+      const call: any = calls[idx];
+      expect(call[0]).toBe(l);
+      expect(call[2]).toEqual({ passive: true });
+    });
+
+    expect(onSwiping).not.toHaveBeenCalled();
+    expect(defaultPrevented).toBe(0);
+  });
+
+  it("preventScrollOnSwipe overwrites touchEventOptions passive", () => {
+    const onSwiping = jest.fn();
+
+    // set to document to start to avoid TS issues
+    let addEventListenerSpy = jest.spyOn(document, "addEventListener");
+    const onRefPassThrough = (el: HTMLElement) => {
+      if (el === null) return;
+      // re-assign to element and spy
+      addEventListenerSpy = jest.spyOn(el, "addEventListener");
+    };
+
+    render(
+      <SwipeableUsingHook
+        onSwiping={onSwiping}
+        onRefPassThrough={onRefPassThrough}
+        preventScrollOnSwipe
+      />
+    );
+
+    expect(addEventListenerSpy.mock.calls.length).toBe(3);
+    const calls = addEventListenerSpy.mock.calls;
+    touchListeners.forEach((l, idx) => {
+      const call: any = calls[idx];
+      expect(call[0]).toBe(l);
+      if (l === touchMove) {
+        // preventScrollOnSwipe overrides passive for touchmove
+        expect(call[2]).toEqual({ passive: false });
+      } else {
+        expect(call[2]).toEqual({ passive: true });
+      }
+    });
+
+    expect(onSwiping).not.toHaveBeenCalled();
+    expect(defaultPrevented).toBe(0);
+  });
+
+  it("changing touchEventOptions.passive re-attaches event listeners", () => {
+    const onSwiping = jest.fn();
+
+    // set to document to start to avoid TS issues
+    let addEventListenerSpy = jest.spyOn(document, "addEventListener");
+    const onRefPassThrough = (el: HTMLElement) => {
+      if (el === null) return;
+      // re-assign to element and spy
+      addEventListenerSpy = jest.spyOn(el, "addEventListener");
+    };
+
+    const { rerender } = render(
+      <SwipeableUsingHook
+        onSwiping={onSwiping}
+        onRefPassThrough={onRefPassThrough}
+      />
+    );
+
+    expect(addEventListenerSpy.mock.calls.length).toBe(3);
+    let calls = addEventListenerSpy.mock.calls;
+    touchListeners.forEach((l, idx) => {
+      const call: any = calls[idx];
+      expect(call[0]).toBe(l);
+      expect(call[2]).toEqual({ passive: true });
+    });
+
+    expect(onSwiping).not.toHaveBeenCalled();
+    expect(defaultPrevented).toBe(0);
+
+    // reset spy before re-render
+    addEventListenerSpy.mockClear();
+
+    // change touchEventOptions.passive from default
+    rerender(
+      <SwipeableUsingHook
+        onSwiping={onSwiping}
+        onRefPassThrough={onRefPassThrough}
+        touchEventOptions={{ passive: false }}
+      />
+    );
+
+    expect(addEventListenerSpy.mock.calls.length).toBe(3);
+    calls = addEventListenerSpy.mock.calls;
+    touchListeners.forEach((l, idx) => {
+      const call: any = calls[idx];
+      expect(call[0]).toBe(l);
+      expect(call[2]).toEqual({ passive: false });
+    });
+
+    expect(onSwiping).not.toHaveBeenCalled();
+    expect(defaultPrevented).toBe(0);
   });
 
   it("does not fire onSwiped when under delta", () => {

--- a/examples/app/SimpleCarousel/Carousel.tsx
+++ b/examples/app/SimpleCarousel/Carousel.tsx
@@ -42,7 +42,7 @@ const Carousel: FunctionComponent = (props) => {
   const handlers = useSwipeable({
     onSwipedLeft: () => slide(NEXT),
     onSwipedRight: () => slide(PREV),
-    onTouchStartOrOnMouseDown: (({ event }) => (console.log('yup'),event.preventDefault())),
+    onTouchStartOrOnMouseDown: (({ event }) => event.preventDefault()),
     touchEventOptions: { passive: false },
     trackMouse: true
   });

--- a/examples/app/SimpleCarousel/Carousel.tsx
+++ b/examples/app/SimpleCarousel/Carousel.tsx
@@ -42,7 +42,8 @@ const Carousel: FunctionComponent = (props) => {
   const handlers = useSwipeable({
     onSwipedLeft: () => slide(NEXT),
     onSwipedRight: () => slide(PREV),
-    preventScrollOnSwipe: true,
+    onTouchStartOrOnMouseDown: (({ event }) => (console.log('yup'),event.preventDefault())),
+    touchEventOptions: { passive: false },
     trackMouse: true
   });
 

--- a/examples/app/SimpleCarousel/index.tsx
+++ b/examples/app/SimpleCarousel/index.tsx
@@ -18,6 +18,9 @@ function SimpleCarousel() {
         <Item img="https://unsplash.it/478/205" />
         <Item img="https://unsplash.it/479/205" />
       </Carousel>
+      <h6>
+        <a href="https://github.com/FormidableLabs/react-swipeable/blob/main/examples/app/SimpleCarousel/Carousel.tsx">See code</a> for example usage of <code>onTouchStartOrMouseDown</code> and <code>touchEventOptions</code>
+      </h6>
     </div>
   );
 }

--- a/examples/app/SimplePattern/index.tsx
+++ b/examples/app/SimplePattern/index.tsx
@@ -17,6 +17,9 @@ function SimplePattern() {
         <Item img="https://unsplash.it/478/205" />
         <Item img="https://unsplash.it/479/205" />
       </Carousel>
+      <h6>
+        <a href="https://github.com/FormidableLabs/react-swipeable/blob/main/examples/app/SimplePattern/pattern.tsx">See code</a> for example usage of <code style={{ whiteSpace: "nowrap" }}>touch-action: none</code> to prevent scrolling.
+      </h6>
     </div>
   );
 }

--- a/examples/app/SimplePattern/pattern.tsx
+++ b/examples/app/SimplePattern/pattern.tsx
@@ -81,13 +81,12 @@ const Carousel: FunctionComponent = (props) => {
 
   const handlers = useSwipeable({
     onSwiped: handleSwiped,
-    preventScrollOnSwipe: true,
     trackMouse: true
   });
 
   return (
     <>
-      <PatternBox {...handlers}>
+      <PatternBox {...handlers} style={{ touchAction: 'none' }}>
         Swipe the pattern below, within this box, to make the carousel go to the next
         slide
         {`\n`}
@@ -99,7 +98,7 @@ const Carousel: FunctionComponent = (props) => {
           <D><DownArrow active={pIdx > 3} /></D>
         </p>
       </PatternBox>
-      <div>
+      <div style={{paddingBottom: '15px'}}>
         <Wrapper>
           <CarouselContainer dir={state.dir} sliding={state.sliding}>
             {React.Children.map(props.children, (child, index) => (

--- a/examples/app/components.tsx
+++ b/examples/app/components.tsx
@@ -42,6 +42,7 @@ export const CarouselSlot = styled.div<{ order: number }>`
 export const SlideButtonContainer = styled.div`
   display: flex;
   justify-content: space-between;
+  padding-bottom: 10px;
 `;
 
 export const SlideButton = styled.button<{ float: 'left' | 'right' }>`

--- a/package.json
+++ b/package.json
@@ -34,15 +34,15 @@
   },
   "size-limit": [
     {
-      "limit": "1.2 KB",
+      "limit": "1.25 KB",
       "path": "dist/react-swipeable.js"
     },
     {
-      "limit": "1.2 KB",
+      "limit": "1.25 KB",
       "path": "dist/react-swipeable.umd.js"
     },
     {
-      "limit": "1.25 KB",
+      "limit": "1.28 KB",
       "path": "dist/react-swipeable.module.js"
     }
   ],

--- a/src/index.ts
+++ b/src/index.ts
@@ -214,6 +214,9 @@ function getHandlers(
       } else {
         props.onTap && props.onTap({ event });
       }
+
+      props.onTouchEndOrOnMouseUp && props.onTouchEndOrOnMouseUp({ event });
+
       return { ...state, ...initialState, eventData };
     });
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,6 +108,8 @@ function getHandlers(
         "touches" in event ? event.touches[0] : event;
       const xy = rotateXYByAngle([clientX, clientY], props.rotationAngle);
 
+      props.onTouchStartOrOnMouseDown && props.onTouchStartOrOnMouseDown({ event });
+
       return {
         ...state,
         ...initialState,

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,8 @@ import {
   LEFT,
   RIGHT,
   Setter,
-  SwipeableCallbacks,
+  ConfigurationOptions,
+  SwipeableDirectionCallbacks,
   SwipeableHandlers,
   SwipeableProps,
   SwipeablePropsWithDefaultOptions,
@@ -27,6 +28,7 @@ export {
   DOWN,
   SwipeDirections,
   SwipeEventData,
+  SwipeableDirectionCallbacks,
   SwipeCallback,
   TapCallback,
   SwipeableHandlers,
@@ -34,12 +36,13 @@ export {
   Vector2,
 };
 
-const defaultProps = {
+const defaultProps: ConfigurationOptions = {
   delta: 10,
   preventScrollOnSwipe: false,
   rotationAngle: 0,
   trackMouse: false,
   trackTouch: true,
+  touchEventOptions: { passive: true },
 };
 const initialState: SwipeableState = {
   first: true,
@@ -169,7 +172,7 @@ function getHandlers(
       if (
         props.onSwiping ||
         props.onSwiped ||
-        props[`onSwiped${dir}` as keyof SwipeableCallbacks]
+        props[`onSwiped${dir}` as keyof SwipeableDirectionCallbacks]
       ) {
         cancelablePageSwipe = true;
       }
@@ -201,7 +204,9 @@ function getHandlers(
         props.onSwiped && props.onSwiped(eventData);
 
         const onSwipedDir =
-          props[`onSwiped${eventData.dir}` as keyof SwipeableCallbacks];
+          props[
+            `onSwiped${eventData.dir}` as keyof SwipeableDirectionCallbacks
+          ];
         onSwipedDir && onSwipedDir(eventData);
       } else {
         props.onTap && props.onTap({ event });
@@ -222,26 +227,41 @@ function getHandlers(
   };
 
   /**
-   * Switch of "passive" property for now.
    * The value of passive on touchMove depends on `preventScrollOnSwipe`:
    * - true => { passive: false }
-   * - false => { passive: true }
+   * - false => { passive: true } // Default
    *
-   * When passive is false, we can (and do) call preventDefault to prevent scroll. When it is true,
-   * the browser ignores any calls to preventDefault and logs a warning.
+   * NOTE: When preventScrollOnSwipe is true, we attempt to call preventDefault to prevent scroll.
+   *
+   * props.touchEventOptions can also be set for all touch event listeners,
+   * but for `touchmove` specifically when `preventScrollOnSwipe` it will
+   * supersede and force passive to false.
+   *
    */
-  const attachTouch: AttachTouch = (el, passiveOnTouchMove) => {
+  const attachTouch: AttachTouch = (el, props) => {
     let cleanup = () => {};
     if (el && el.addEventListener) {
+      const baseOptions = {
+        ...defaultProps.touchEventOptions,
+        ...props.touchEventOptions,
+      };
       // attach touch event listeners and handlers
       const tls: [
         typeof touchStart | typeof touchMove | typeof touchEnd,
         (e: HandledEvents) => void,
         { passive: boolean }
       ][] = [
-        [touchStart, onStart, { passive: true }],
-        [touchMove, onMove, { passive: passiveOnTouchMove }],
-        [touchEnd, onEnd, { passive: true }],
+        [touchStart, onStart, baseOptions],
+        // preventScrollOnSwipe option supersedes touchEventOptions.passive
+        [
+          touchMove,
+          onMove,
+          {
+            ...baseOptions,
+            ...(props.preventScrollOnSwipe ? { passive: false } : {}),
+          },
+        ],
+        [touchEnd, onEnd, baseOptions],
       ];
       tls.forEach(([e, h, o]) => el.addEventListener(e, h, o));
       // return properly scoped cleanup method for removing listeners, options not required
@@ -266,7 +286,7 @@ function getHandlers(
       }
       // only attach if we want to track touch
       if (props.trackTouch && el) {
-        addState.cleanUpTouch = attachTouch(el, !props.preventScrollOnSwipe);
+        addState.cleanUpTouch = attachTouch(el, props);
       }
 
       // store event attached DOM el for comparison, clean up, and re-attachment
@@ -293,7 +313,7 @@ function updateTransientState(
   previousProps: SwipeablePropsWithDefaultOptions,
   attachTouch: AttachTouch
 ) {
-  // if trackTouch is off or there is no el, then remove handlers if necessesary and exit
+  // if trackTouch is off or there is no el, then remove handlers if necessary and exit
   if (!props.trackTouch || !state.el) {
     if (state.cleanUpTouch) {
       state.cleanUpTouch();
@@ -309,19 +329,22 @@ function updateTransientState(
   if (!state.cleanUpTouch) {
     return {
       ...state,
-      cleanUpTouch: attachTouch(state.el, !props.preventScrollOnSwipe),
+      cleanUpTouch: attachTouch(state.el, props),
     };
   }
 
   // trackTouch is on and handlers are already attached, so if preventScrollOnSwipe changes value,
   // remove and reattach handlers (this is required to update the passive option when attaching
   // the handlers)
-  if (props.preventScrollOnSwipe !== previousProps.preventScrollOnSwipe) {
+  if (
+    props.preventScrollOnSwipe !== previousProps.preventScrollOnSwipe ||
+    props.touchEventOptions.passive !== previousProps.touchEventOptions.passive
+  ) {
     state.cleanUpTouch();
 
     return {
       ...state,
-      cleanUpTouch: attachTouch(state.el, !props.preventScrollOnSwipe),
+      cleanUpTouch: attachTouch(state.el, props),
     };
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,7 +108,8 @@ function getHandlers(
         "touches" in event ? event.touches[0] : event;
       const xy = rotateXYByAngle([clientX, clientY], props.rotationAngle);
 
-      props.onTouchStartOrOnMouseDown && props.onTouchStartOrOnMouseDown({ event });
+      props.onTouchStartOrOnMouseDown &&
+        props.onTouchStartOrOnMouseDown({ event });
 
       return {
         ...state,

--- a/src/types.ts
+++ b/src/types.ts
@@ -129,6 +129,9 @@ export interface ConfigurationOptions {
    * Track touch input. **Default**: `true`
    */
   trackTouch: boolean;
+  /**
+   * Options for touch event listeners
+   */
   touchEventOptions: { passive: boolean };
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,7 @@ export type SwipeableDirectionCallbacks = {
 
 export type SwipeableCallbacks = SwipeableDirectionCallbacks & {
   // Event handler/callbacks
+  onTouchStartOrOnMouseDown: TapCallback;
   onSwipeStart: SwipeCallback;
   onSwiped: SwipeCallback;
   onSwiping: SwipeCallback;

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,11 +36,18 @@ export type SwipeableDirectionCallbacks = {
 
 export type SwipeableCallbacks = SwipeableDirectionCallbacks & {
   // Event handler/callbacks
-  onTouchStartOrOnMouseDown: TapCallback;
   onSwipeStart: SwipeCallback;
   onSwiped: SwipeCallback;
   onSwiping: SwipeCallback;
   onTap: TapCallback;
+  /**
+   * Called for `touchstart` and `mousedown`.
+   */
+  onTouchStartOrOnMouseDown: TapCallback;
+  /**
+   * Called for `touchend` and `mouseup`.
+   */
+  onTouchEndOrOnMouseUp: TapCallback;
 };
 
 // Configuration Options

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,14 +27,17 @@ export interface SwipeEventData {
 export type SwipeCallback = (eventData: SwipeEventData) => void;
 export type TapCallback = ({ event }: { event: HandledEvents }) => void;
 
-export type SwipeableCallbacks = {
-  // Event handler/callbacks
-  onSwipeStart: SwipeCallback;
-  onSwiped: SwipeCallback;
+export type SwipeableDirectionCallbacks = {
   onSwipedDown: SwipeCallback;
   onSwipedLeft: SwipeCallback;
   onSwipedRight: SwipeCallback;
   onSwipedUp: SwipeCallback;
+};
+
+export type SwipeableCallbacks = SwipeableDirectionCallbacks & {
+  // Event handler/callbacks
+  onSwipeStart: SwipeCallback;
+  onSwiped: SwipeCallback;
   onSwiping: SwipeCallback;
   onTap: TapCallback;
 };
@@ -49,6 +52,7 @@ export interface ConfigurationOptions {
   rotationAngle: number;
   trackMouse: boolean;
   trackTouch: boolean;
+  touchEventOptions: { passive: boolean };
 }
 
 export type SwipeableProps = Partial<SwipeableCallbacks & ConfigurationOptions>;
@@ -79,5 +83,5 @@ export type StateSetter = (
 export type Setter = (stateSetter: StateSetter) => void;
 export type AttachTouch = (
   el: HTMLElement,
-  passiveOnTouchMove: boolean
+  props: SwipeablePropsWithDefaultOptions
 ) => () => void;


### PR DESCRIPTION
#288 

includes #287 as `onTouchStartOrOnMouseDown` prop
- allows for `preventDefault` calling on touch start with new `passive: false` touch event options prop

add `onTouchEndOrOnMouseUp` prop to allow access to the `touchend` and `mouseup` events no matter if we are tracking a swipe or not

#### TODO
- [x] update readme