### PR TITLE
add document example codesandbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,8 +150,6 @@ useEffect(() => {
 });
 ```
 
-
-
 ### How to share `ref` from `useSwipeable`?
 
 **Example ref passthrough, [more details #189](https://github.com/FormidableLabs/react-swipeable/issues/189#issuecomment-656302682):**

--- a/README.md
+++ b/README.md
@@ -136,6 +136,10 @@ If you would like something similar to the old `<Swipeable>` component you can r
 
 ### How can I add a swipe listener to the `document`?
 Example by [@merrywhether #180](https://github.com/FormidableLabs/react-swipeable/issues/180#issuecomment-649677983)
+
+##### Example codesandbox with swipeable on document and nested swipe
+https://codesandbox.io/s/react-swipeable-document-swipe-example-1yvr2v
+
 ```js
 const { ref } = useSwipeable({
   ...
@@ -145,6 +149,8 @@ useEffect(() => {
   ref(document);
 });
 ```
+
+
 
 ### How to share `ref` from `useSwipeable`?
 


### PR DESCRIPTION
solution from discussion:
https://github.com/FormidableLabs/react-swipeable/issues/274#issuecomment-1049509166

Add to readme as example for attaching swipeable to `document`