### PR TITLE
update baseUrl for docusaurus site

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -7,7 +7,7 @@ const config: Config = {
   tagline: "Customizable, fast, and lightweight React hook which provides all the information needed for your site to manage swipe interactions.",
   favicon: "img/nearform-icon.svg",
   url: "https://commerce.nearform.com/",
-  baseUrl: "/",
+  baseUrl: "/open-source/react-swipeable",
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "warn",
   i18n: {


### PR DESCRIPTION
<!--

Have you read Formidable's Code of Conduct? By filing an Issue, you are expected to comply with it, including treating everyone with respect: https://github.com/FormidableLabs/.github/blob/master/CODE_OF_CONDUCT.md

-->

### Description

In order for the site to be rendered correctly, the `baseUrl` needs to be set so that commerce.nearform.com/open-source/react-swipeable triggers the vercel app to open. Setting the `baseUrl` should fix this.

<img width="749" alt="image" src="https://github.com/FormidableLabs/react-swipeable/assets/3632381/2035d870-b531-496c-a977-c3dc3cb00790">

#### Type of Change

<!-- Please delete options that are not relevant (including this descriptive text). -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration. -->

### Checklist: (Feel free to delete this section upon completion)

- [ ] I have included a changeset if this change will require a version change to one of the packages.
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have run all builds, tests, and linting and all checks pass
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream modules
